### PR TITLE
Raspberry Pi 4 (and arm64) support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
-all : osccal.bin burn
+all : tpiflash
 
 AVRPART=attiny10
 AVRCFLAGS=-g -Wall -Os -mmcu=$(AVRPART) -DF_CPU=8000000UL
 AVRASFLAGS:=$(AVRCFLAGS)
 
-
 tpiflash : gpio_tpi.c gen_ios.c tpiflash.c
-	gcc -o $@ $^ -Os
+	gcc -o tpiflash $^
+	gcc -o tpiflash_rpi4 $^ -DRPI_4
 
 firmware.bin : firmware.c firmware.S
 	avr-gcc -I  -g $(AVRCFLAGS)   -mmcu=$(AVRPART) -Wl,-Map,firmware.map -o firmware.elf $^

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # pi_tpi
-Using a Raspberry Pi to program an ATTiny4/5/9/10.  But, mostly the $0.25 ATTiny10.  And, not necessarily a Raspberry Pi, but anything with GPIOs!
+Using a Raspberry Pi to program an ATTiny4/5/9/10.  But, mostly the $0.25 ATTiny10.  And, not necessarily a Raspberry Pi, but anything with GPIOs! After compiling with ```make```, you can use ```tpiflash``` on Raspberry Pi < 4, and ```tpiflash_rpi4``` on Raspberry Pi 4.
 
 Yep.  It works.  At least tested pretty thurrougly with my ATTiny10.  It can also read all the memories _AND_ run timings against the AVR to do processor clock calibration, as well as fuses and manual poking to flash en post to allow for custom configuration.
 


### PR DESCRIPTION
In this pull request, there are two changes:
1) Modified Makefile to not build and burn avr binaries.
2) Updated code to work with Raspberry Pi 4 (two binaries are now created, tpiflash_rpi4 and tpiflash)