### PR TITLE
fix error handling in mmap()

### DIFF
--- a/gen_ios.c
+++ b/gen_ios.c
@@ -33,9 +33,10 @@ int InitGenGPIO()
 	//map a page of memory to gpio at offset 0x20200000 which is where GPIO goodnessstarts
 	gpiomem = (uint32_t *)mmap(0, pagesize, PROT_READ|PROT_WRITE, MAP_SHARED, gpiofd, GPIO_BASE );
 
-	if ((int32_t)gpiomem < 0)
+	// if ((int32_t)gpiomem < 0)
+	if (gpiomem == MAP_FAILED)
 	{
-		printf("Mmap (GPIO) failed: %s\n", strerror(errno));
+		fprintf(stderr, "Mmap (GPIO) failed: error was %s\n", strerror(errno));
 		gpiomem = 0;
 		gpiofd = 0;
 		close( gpiofd );

--- a/gpio_tpi.c
+++ b/gpio_tpi.c
@@ -8,7 +8,7 @@
 //	https://pcm1723.hateblo.jp/entry/20111208/1323351725
 
 
-void ClockDelay() { int i = 1000; do { asm volatile ("nop"); } while( i-- ); } //700ksps (slow enough)
+void ClockDelay() { int i = 1000; do { asm volatile ("nop"); } while( i-- ); } //700ksps (@i = 500) (slow enough for most systems) ... on further use, i = 1000 seems more reliable.
 
 int did_send_last = 0;
 

--- a/gpio_tpi.c
+++ b/gpio_tpi.c
@@ -8,7 +8,7 @@
 //	https://pcm1723.hateblo.jp/entry/20111208/1323351725
 
 
-void ClockDelay() { int i = 1000; do { asm volatile ("nop"); } while( i-- ); } //700ksps (@i = 500) (slow enough for most systems) ... on further use, i = 1000 seems more reliable.
+void ClockDelay() { int i = 1000; do { asm volatile ("nop"); } while( i-- ); } //700ksps (slow enough)
 
 int did_send_last = 0;
 
@@ -102,7 +102,11 @@ void TPIBreak()
 int TPIInit()
 {
 	int i;
-	InitGenGPIO();
+	int err = InitGenGPIO();
+	if (err != 0) {
+		printf("TPIInit(): Gpio init failed, InitGenGPIO() returned %i", err);
+		return err;
+	}
 
 	//NOTE: MUST HAVE PULL-UP ON DAT.
 

--- a/gpio_tpi.c
+++ b/gpio_tpi.c
@@ -104,7 +104,7 @@ int TPIInit()
 	int i;
 	int err = InitGenGPIO();
 	if (err != 0) {
-		printf("TPIInit(): Gpio init failed, InitGenGPIO() returned %i", err);
+		fprintf(stderr, "TPIInit(): Gpio init failed, InitGenGPIO() returned %i", err);
 		return err;
 	}
 


### PR DESCRIPTION
Fix 2 things:

1. On ancient GCC, check the error code for mmap() as an explicit consttant
What was there should have been fine, but, I guess our gcc is ancient.
```bash
avr-gcc --version
avr-gcc (GCC) 5.4.0
```

this:
```c
if ((int32_t)gpiomem < 0)
```
was changed to:
```c
if (gpiomem == MAP_FAILED)
```

and it worked fine.

2. Fix segfault if InitGenGPIO() because the return value wasn't checked. Now it at least bails with the correct error.